### PR TITLE
サ活登録画面のUI実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,6 +77,9 @@ dependencies {
     // Hilt
     implementation "com.google.dagger:hilt-android:2.44"
     kapt "com.google.dagger:hilt-compiler:2.44"
+
+    // Material Design
+    implementation 'com.google.android.material:material:1.7.0'
 }
 
 kapt {

--- a/app/src/main/java/com/theuhooi/totonoi/MainActivity.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.Window
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.safeDrawing
@@ -18,7 +19,7 @@ import androidx.core.view.WindowCompat
 import com.theuhooi.totonoi.core.ui.TotonoiApp
 import com.theuhooi.totonoi.core.ui.theme.TotonoiTheme
 
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)

--- a/app/src/main/java/com/theuhooi/totonoi/core/ui/TotonoiApp.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/core/ui/TotonoiApp.kt
@@ -11,6 +11,6 @@ fun TotonoiApp() {
     val navController = rememberNavController()
 
     NavHost(navController = navController, startDestination = TopDestination.SakatsuList.route) {
-        topNavGraph()
+        topNavGraph(navController = navController)
     }
 }

--- a/app/src/main/java/com/theuhooi/totonoi/core/ui/navigator/TopNavGraph.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/core/ui/navigator/TopNavGraph.kt
@@ -16,7 +16,11 @@ fun NavGraphBuilder.topNavGraph(navController: NavController) {
         )
     }
     composable(TopDestination.SakatuInput.route) {
-        SakatsuInputScreen()
+        SakatsuInputScreen(
+            onNavigationClick = {
+                navController.popBackStack()
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/theuhooi/totonoi/core/ui/navigator/TopNavGraph.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/core/ui/navigator/TopNavGraph.kt
@@ -1,16 +1,22 @@
 package com.theuhooi.totonoi.core.ui.navigator
 
+import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import com.theuhooi.totonoi.feature.sakatsu.sakatsu_input.SakatsuInputScreen
 import com.theuhooi.totonoi.feature.sakatsu.sakatsu_list.SakatsuListScreen
 
-fun NavGraphBuilder.topNavGraph() {
+fun NavGraphBuilder.topNavGraph(navController: NavController) {
     composable(TopDestination.SakatsuList.route) {
-        SakatsuListScreen()
+        SakatsuListScreen(
+            onFabClick = {
+                navController.navigate(TopDestination.SakatuInput.route)
+            }
+        )
     }
     composable(TopDestination.SakatuInput.route) {
-        TODO("implement SakatsuInputScreen")
+        SakatsuInputScreen()
     }
 }
 

--- a/app/src/main/java/com/theuhooi/totonoi/core/ui/theme/Color.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/core/ui/theme/Color.kt
@@ -4,6 +4,8 @@ import androidx.compose.ui.graphics.Color
 
 val Pink200 = Color(0xFFf48fb1)
 
+val LightBlue50 = Color(0xFFe1f5fe)
+val LightBlue100 = Color(0xFFb3e5fc)
 val LightBlue200 = Color(0xFF81d4fa)
 
 val Amber600 = Color(0xFFffb300)

--- a/app/src/main/java/com/theuhooi/totonoi/core/ui/theme/Theme.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/core/ui/theme/Theme.kt
@@ -20,10 +20,11 @@ private val DarkColorScheme = darkColorScheme(
     secondary = Amber600,
     tertiary = Pink200,
     background = Gray100,
-    surface = White,
+    surface = LightBlue50,
     onPrimary = Gray900,
     onBackground = Black,
     error = DeepOrange400,
+    onSurfaceVariant = Gray100
 )
 
 private val LightColorScheme = lightColorScheme(
@@ -31,10 +32,11 @@ private val LightColorScheme = lightColorScheme(
     secondary = Amber600,
     tertiary = Pink200,
     background = Gray100,
-    surface = White,
+    surface = LightBlue50,
     onPrimary = Gray900,
     onBackground = Black,
     error = DeepOrange400,
+    onSurfaceVariant = Gray100
 
 
     /* Other default colors to override

--- a/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_input/SakatsuInputScreen.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_input/SakatsuInputScreen.kt
@@ -1,0 +1,8 @@
+package com.theuhooi.totonoi.feature.sakatsu.sakatsu_input
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun SakatsuInputScreen() {
+
+}

--- a/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_input/SakatsuInputScreen.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_input/SakatsuInputScreen.kt
@@ -1,8 +1,34 @@
 package com.theuhooi.totonoi.feature.sakatsu.sakatsu_input
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.theuhooi.totonoi.R
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SakatsuInputScreen() {
+fun SakatsuInputScreen(
+    onNavigationClick: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(text = stringResource(id = R.string.sakatsu_input_title))
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigationClick) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = stringResource(id = R.string.talkback_back)
+                        )
+                    }
+                }
+            )
+        }
+    ) {
 
+    }
 }

--- a/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_input/SakatsuInputScreen.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_input/SakatsuInputScreen.kt
@@ -1,17 +1,28 @@
 package com.theuhooi.totonoi.feature.sakatsu.sakatsu_input
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.theuhooi.totonoi.R
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLifecycleComposeApi::class)
 @Composable
 fun SakatsuInputScreen(
     onNavigationClick: () -> Unit,
+    viewModel: SakatsuInputViewModel = viewModel()
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     Scaffold(
         topBar = {
             TopAppBar(
@@ -25,10 +36,40 @@ fun SakatsuInputScreen(
                             contentDescription = stringResource(id = R.string.talkback_back)
                         )
                     }
+                },
+                actions = {
+                    Text(
+                        modifier = Modifier
+                            .clickable(
+                                enabled = uiState.isSaveButtonEnabled,
+                                onClick = viewModel::onSaveButtonClick
+                            ),
+                        text = stringResource(id = R.string.save),
+                        color = if (uiState.isSaveButtonEnabled) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        }
+                    )
                 }
             )
         }
-    ) {
-
+    ) { contentPadding ->
+        Box(modifier = Modifier.padding(top = contentPadding.calculateTopPadding())) {
+            SakatsuInputSections(
+                modifier = Modifier.fillMaxSize(),
+                facilityName = uiState.facilityName,
+                visitingDateText = uiState.visitingDateText,
+                saunaSetList = uiState.saunaSetList,
+                description = uiState.description,
+                onFacilityNameChange = viewModel::onFacilityNameChange,
+                onVisitingDateChange = viewModel::onVisitingDateChange,
+                onSaunaTimeChange = viewModel::onSaunaTimeChange,
+                onCoolBathTimeChange = viewModel::onCoolBathTimeChange,
+                onRelaxationTimeChange = viewModel::onRelaxationTimeChange,
+                onDescriptionChange = viewModel::onDescriptionChange,
+                onAddSaunaSetClick = viewModel::onAddSaunaSetClick
+            )
+        }
     }
 }

--- a/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_input/SakatsuInputSections.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_input/SakatsuInputSections.kt
@@ -1,0 +1,272 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.theuhooi.totonoi.feature.sakatsu.sakatsu_input
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.google.android.material.datepicker.MaterialDatePicker
+import com.theuhooi.totonoi.R
+
+@Composable
+fun SakatsuInputSections(
+    facilityName: String?,
+    visitingDateText: String,
+    saunaSetList: List<SaunaSet>,
+    description: String?,
+    onFacilityNameChange: (String) -> Unit,
+    onVisitingDateChange: (Long) -> Unit,
+    onSaunaTimeChange: (saunaSetIndex: Int, saunaTime: String) -> Unit,
+    onCoolBathTimeChange: (saunaSetIndex: Int, coolBathTime: String) -> Unit,
+    onRelaxationTimeChange: (saunaSetIndex: Int, relaxationTime: String) -> Unit,
+    onDescriptionChange: (String) -> Unit,
+    onAddSaunaSetClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val bottomInsets = with(LocalDensity.current) {
+        WindowInsets.safeDrawing.getBottom(this).toDp()
+    }
+    LazyColumn(
+        modifier = modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(
+            top = 8.dp,
+            bottom = 32.dp + bottomInsets,
+            start = 16.dp,
+            end = 16.dp
+        )
+    ) {
+        item {
+            FacilityNameSection(
+                modifier = Modifier.fillMaxWidth(),
+                facilityName = facilityName,
+                onFacilityNameChange = onFacilityNameChange
+            )
+        }
+        item {
+            VisitingDateSection(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                visitingDateText = visitingDateText,
+                onVisitingDateChange = onVisitingDateChange
+            )
+        }
+        items(saunaSetList.size) {
+            SaunaSetSection(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+                index = it,
+                saunaTime = saunaSetList[it].saunaTime,
+                coolBathTime = saunaSetList[it].coolBathTime,
+                relaxationTime = saunaSetList[it].relaxationTime,
+                onSaunaTimeChange = onSaunaTimeChange,
+                onCoolBathTimeChange = onCoolBathTimeChange,
+                onRelaxationTimeChange = onRelaxationTimeChange
+            )
+        }
+        item {
+            Text(
+                modifier = Modifier
+                    .padding(top = 24.dp)
+                    .clickable(onClick = onAddSaunaSetClick),
+                text = stringResource(id = R.string.sakatsu_input_add_sauna_set),
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+        item {
+            DescriptionSection(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 24.dp),
+                description = description,
+                onDescriptionChange = onDescriptionChange
+            )
+        }
+    }
+}
+
+@Composable
+private fun FacilityNameSection(
+    facilityName: String?,
+    onFacilityNameChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    OutlinedTextField(
+        modifier = modifier,
+        value = facilityName.orEmpty(),
+        onValueChange = onFacilityNameChange,
+        label = {
+            Text(text = stringResource(id = R.string.sakatsu_input_facility_name))
+        }
+    )
+}
+
+@Composable
+private fun VisitingDateSection(
+    visitingDateText: String,
+    onVisitingDateChange: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val activity = LocalContext.current as AppCompatActivity
+    Box(
+        modifier = modifier
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.outline,
+                shape = RoundedCornerShape(4.dp)
+            )
+            .clip(shape = RoundedCornerShape(4.dp))
+            .clickable {
+                MaterialDatePicker.Builder
+                    .datePicker()
+                    .setTheme(R.style.MaterialCalendarTheme)
+                    .build()
+                    .apply {
+                        show(activity.supportFragmentManager, "DatePicker")
+                        addOnPositiveButtonClickListener {
+                            onVisitingDateChange(it)
+                        }
+                    }
+            }
+    ) {
+        Text(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .padding(start = 12.dp),
+            text = stringResource(id = R.string.sakatsu_input_visiting_date)
+        )
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 20.dp),
+            text = visitingDateText,
+            textAlign = TextAlign.End
+        )
+    }
+}
+
+@Composable
+private fun SaunaSetSection(
+    index: Int,
+    saunaTime: String?,
+    coolBathTime: String?,
+    relaxationTime: String?,
+    onSaunaTimeChange: (saunaSetIndex: Int, saunaTime: String) -> Unit,
+    onCoolBathTimeChange: (saunaSetIndex: Int, coolBathTime: String) -> Unit,
+    onRelaxationTimeChange: (saunaSetIndex: Int, relaxationTime: String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(id = R.string.sakatsu_input_sauna_set_label, index + 1),
+            style = MaterialTheme.typography.labelSmall,
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+        Row(modifier = Modifier.fillMaxWidth()) {
+            OutlinedTextField(
+                modifier = Modifier.weight(1f),
+                value = saunaTime.orEmpty(),
+                onValueChange = { onSaunaTimeChange(index, it) },
+                label = {
+                    Text(text = stringResource(id = R.string.sakatsu_input_sauna_label))
+                },
+                placeholder = {
+                    Text(
+                        text = stringResource(id = R.string.option),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            )
+            Spacer(modifier = Modifier.width(2.dp))
+            Text(
+                modifier = Modifier.align(Alignment.Bottom),
+                text = stringResource(id = R.string.timeunit_minute)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(modifier = Modifier.fillMaxWidth()) {
+            OutlinedTextField(
+                modifier = Modifier.weight(1f),
+                value = coolBathTime.orEmpty(),
+                onValueChange = { onCoolBathTimeChange(index, it) },
+                label = {
+                    Text(text = stringResource(id = R.string.sakatsu_input_cool_bath_label))
+                },
+                placeholder = {
+                    Text(
+                        text = stringResource(id = R.string.option),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            )
+            Spacer(modifier = Modifier.width(2.dp))
+            Text(
+                modifier = Modifier.align(Alignment.Bottom),
+                text = stringResource(id = R.string.timeunit_second)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(modifier = Modifier.fillMaxWidth()) {
+            OutlinedTextField(
+                modifier = Modifier.weight(1f),
+                value = relaxationTime.orEmpty(),
+                onValueChange = { onRelaxationTimeChange(index, it) },
+                label = {
+                    Text(text = stringResource(id = R.string.sakatsu_input_relaxation_label))
+                },
+                placeholder = {
+                    Text(
+                        text = stringResource(id = R.string.option),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            )
+            Spacer(modifier = Modifier.width(2.dp))
+            Text(
+                modifier = Modifier.align(Alignment.Bottom),
+                text = stringResource(id = R.string.timeunit_minute)
+            )
+        }
+
+    }
+}
+
+@Composable
+private fun DescriptionSection(
+    description: String?,
+    onDescriptionChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    OutlinedTextField(
+        modifier = modifier,
+        value = description.orEmpty(),
+        onValueChange = onDescriptionChange,
+        label = {
+            Text(
+                text = stringResource(id = R.string.sakatsu_input_comment)
+            )
+        },
+        placeholder = {
+            Text(
+                text = stringResource(id = R.string.option),
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    )
+}

--- a/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_input/SakatsuInputUiState.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_input/SakatsuInputUiState.kt
@@ -1,0 +1,25 @@
+package com.theuhooi.totonoi.feature.sakatsu.sakatsu_input
+
+import androidx.compose.runtime.Stable
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Stable
+data class SakatsuInputUiState(
+    val facilityName: String? = null,
+    private val visitingDate: LocalDateTime = LocalDateTime.now(),
+    val saunaSetList: List<SaunaSet> = listOf(SaunaSet()),
+    val description: String? = null
+) {
+    val visitingDateText: String
+        get() = DateTimeFormatter.ofPattern("yyyy/MM/dd").format(visitingDate)
+
+    val isSaveButtonEnabled: Boolean
+        get() = facilityName.orEmpty().isNotBlank()
+}
+
+data class SaunaSet(
+    val saunaTime: String? = null,
+    val coolBathTime: String? = null,
+    val relaxationTime: String? = null
+)

--- a/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_input/SakatsuInputViewModel.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_input/SakatsuInputViewModel.kt
@@ -1,0 +1,94 @@
+package com.theuhooi.totonoi.feature.sakatsu.sakatsu_input
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import javax.inject.Inject
+
+@HiltViewModel
+class SakatsuInputViewModel @Inject constructor() : ViewModel() {
+
+    private val _uiState: MutableStateFlow<SakatsuInputUiState> =
+        MutableStateFlow(SakatsuInputUiState())
+    val uiState: StateFlow<SakatsuInputUiState> = _uiState.asStateFlow()
+
+    fun onFacilityNameChange(value: String) {
+        _uiState.update {
+            it.copy(facilityName = value)
+        }
+    }
+
+    fun onVisitingDateChange(value: Long) {
+        val instant = Instant.ofEpochMilli(value)
+        val localDateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
+        _uiState.update {
+            it.copy(visitingDate = localDateTime)
+        }
+    }
+
+    fun onSaunaTimeChange(saunaIndex: Int, saunaTime: String) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                saunaSetList = currentState.saunaSetList.mapIndexed { index, item ->
+                    if (index == saunaIndex) {
+                        item.copy(saunaTime = saunaTime)
+                    } else {
+                        item
+                    }
+                }
+            )
+        }
+    }
+
+    fun onCoolBathTimeChange(saunaIndex: Int, coolBathTime: String) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                saunaSetList = currentState.saunaSetList.mapIndexed { index, item ->
+                    if (index == saunaIndex) {
+                        item.copy(coolBathTime = coolBathTime)
+                    } else {
+                        item
+                    }
+                }
+            )
+        }
+    }
+
+    fun onRelaxationTimeChange(saunaIndex: Int, relaxationTime: String) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                saunaSetList = currentState.saunaSetList.mapIndexed { index, item ->
+                    if (index == saunaIndex) {
+                        item.copy(relaxationTime = relaxationTime)
+                    } else {
+                        item
+                    }
+                }
+            )
+        }
+    }
+
+    fun onDescriptionChange(value: String) {
+        _uiState.update {
+            it.copy(description = value)
+        }
+    }
+
+    fun onAddSaunaSetClick() {
+        _uiState.update { currentState ->
+            currentState.copy(
+                saunaSetList = currentState.saunaSetList.plus(SaunaSet())
+            )
+        }
+    }
+
+    fun onSaveButtonClick() {
+        TODO("implement logic")
+    }
+}

--- a/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_list/SakatsuListScreen.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_list/SakatsuListScreen.kt
@@ -1,22 +1,18 @@
 package com.theuhooi.totonoi.feature.sakatsu.sakatsu_list
 
-import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.compose.rememberNavController
 import com.theuhooi.totonoi.R
-import com.theuhooi.totonoi.core.ui.navigator.TopDestination
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLifecycleComposeApi::class)
 @Composable

--- a/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_list/SakatsuListScreen.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_list/SakatsuListScreen.kt
@@ -33,7 +33,7 @@ fun SakatsuListScreen(viewModel: SakatsuListViewModel = viewModel(), onFabClick:
         floatingActionButton = {
             FloatingActionButton(
                 content = {
-                    Icon(imageVector = Icons.Filled.Add, contentDescription = null)
+                    Icon(imageVector = Icons.Filled.Add, contentDescription = stringResource(id = R.string.talkback_add_sakatsu))
                 },
                 onClick = onFabClick
             )

--- a/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_list/SakatsuListScreen.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_list/SakatsuListScreen.kt
@@ -14,11 +14,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.compose.rememberNavController
 import com.theuhooi.totonoi.R
+import com.theuhooi.totonoi.core.ui.navigator.TopDestination
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLifecycleComposeApi::class)
 @Composable
-fun SakatsuListScreen(viewModel: SakatsuListViewModel = viewModel()) {
+fun SakatsuListScreen(viewModel: SakatsuListViewModel = viewModel(), onFabClick: () -> Unit) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     Scaffold(
@@ -37,7 +39,7 @@ fun SakatsuListScreen(viewModel: SakatsuListViewModel = viewModel()) {
                 content = {
                     Icon(imageVector = Icons.Filled.Add, contentDescription = null)
                 },
-                onClick = { /*TODO*/ }
+                onClick = onFabClick
             )
         }
     ) { contentPadding ->

--- a/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_list/SakatsuListUiState.kt
+++ b/app/src/main/java/com/theuhooi/totonoi/feature/sakatsu/sakatsu_list/SakatsuListUiState.kt
@@ -16,7 +16,7 @@ sealed interface SakatsuListStatus {
 }
 
 data class SakatsuListItemUiState(
-    val title: String,
+    val title: String, // TODO: facilityNameに統一
     val description: String? = null,
     val dateText: String,
     val saunaTimeText: String? = null,

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,8 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
+    <color name="primary">#81d4fa</color>
+    <color name="on_primary">#212121</color>
+    <color name="surface">#e1f5fe</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="timeunit_minute">分</string>
     <string name="timeunit_hour">時間</string>
     <string name="arrow_right">→</string>
+    <string name="option">オプション</string>
+    <string name="save">保存</string>
 
     <!-- サ活一覧 -->
     <string name="sakatsu_list_empty_label">サ活を追加しよう！</string>
@@ -18,6 +20,17 @@
     <string name="emoji_cool_bath">💧</string>
     <string name="emoji_relaxation">🍃</string>
 
+    <!-- サ活登録 -->
+    <string name="sakatsu_input_facility_name">施設名</string>
+    <string name="sakatsu_input_visiting_date">訪問日</string>
+    <string name="sakatsu_input_sauna_set_label">%dセット目</string>
+    <string name="sakatsu_input_sauna_label">サウナ🧖</string>
+    <string name="sakatsu_input_cool_bath_label">水風呂💧</string>
+    <string name="sakatsu_input_relaxation_label">休憩🍃</string>
+    <string name="sakatsu_input_add_sauna_set">新しいセットを追加</string>
+    <string name="sakatsu_input_comment">コメント</string>
+
     <!-- talkback -->
     <string name="talkback_back">戻る</string>
+    <string name="talkback_add_sakatsu">サ活を登録する</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
 
     <!-- Title -->
     <string name="sakatsu_list_title">サ活一覧</string>
+    <string name="sakatsu_input_title">サ活登録</string>
 
     <!-- common -->
     <string name="error">エラー</string>
@@ -16,4 +17,7 @@
     <string name="emoji_sauna">🧖</string>
     <string name="emoji_cool_bath">💧</string>
     <string name="emoji_relaxation">🍃</string>
+
+    <!-- talkback -->
+    <string name="talkback_back">戻る</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Totonoi" parent="android:Theme.Material.Light.NoActionBar" >
+    <style name="Theme.Totonoi" parent="Theme.Material3.Light.NoActionBar" >
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>
+    </style>
+    
+    <style name="MaterialCalendarTheme" parent="ThemeOverlay.Material3.MaterialCalendar">
+        <item name="colorPrimary">@color/primary</item>
+        <item name="colorOnPrimary">@color/on_primary</item>
+        <item name="colorSurface">@color/surface</item>
     </style>
 </resources>


### PR DESCRIPTION
## やったこと
- サ活一覧画面のFABから遷移できるサ活登録画面のUI実装
- 実際に保存するところまでは実装してません

## 確認したこと
- 各セクションが入力可能になっていること
- 施設名を入力すると保存ボタンがenableになること

## Screenshot
|セットが1つ|セットが2つ|
|:---:|:---:|
|![Screenshot_1669131078](https://user-images.githubusercontent.com/62977464/203354867-19f73e01-2262-423a-b620-5436b74177ea.png)|![Screenshot_1669131081](https://user-images.githubusercontent.com/62977464/203354898-7ba9a68c-999b-448d-96f3-ec963ee7051b.png)|